### PR TITLE
Disable monitor on NotionClient for speed boost

### DIFF
--- a/notioncli.py
+++ b/notioncli.py
@@ -20,7 +20,7 @@ def captureStdOut(output):
         sys.stdout = stdout
 
 try:
-    client = NotionClient(token_v2=os.environ['NOTION_TOKEN'])
+    client = NotionClient(token_v2=os.environ['NOTION_TOKEN'], monitor=False)
     page = client.get_block(os.environ['NOTION_PAGE'])
 except:
     cprint('NOTION_TOKEN / NOTION_PAGE environment variables not set.\n', 'red')


### PR DESCRIPTION
I've noticed in my own usage of notion-py, that you can disable the Monitoring
(subscriptions) and save approximately 4s on the initial API connection. It
doesn't look like you are using the subscription aspects so this might just be
a free performance win.