### PR TITLE
Allow fetching non-tasks

### DIFF
--- a/notioncli.py
+++ b/notioncli.py
@@ -66,6 +66,7 @@ def list():
     cprint('#  Status Description','white',attrs=['underline'])
     for child in page.children:
         n += 1
+        check = '   '
         try:
             if child.checked:
                 check = '[*]'


### PR DESCRIPTION
Without this change, the program crashes when there are non-tasks on the list.